### PR TITLE
fix al bug #8 da controllare

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -143,8 +143,8 @@ async def on_message_delete(message):
         if item is None:
             return
     #il contatore non può ovviamente andare sotto 0
-    if item[sharedFunctions.weekdays.get(datetime.today().weekday())] != 0:
-        item[sharedFunctions.weekdays.get(datetime.today().weekday())] -= 1
+    if item["counter"] != 0:
+        item["counter"] -= 1
         sharedFunctions.update_json_file(prev_dict, 'aflers.json')
         print('rimosso un messaggio')
 
@@ -261,7 +261,7 @@ async def periodic_checks():
 
         #controllo sulla data dell'ultima violazione, ed eventuale reset
         if item["last_violation_count"] is not None:
-            expiration = datetime.date(datetime.strptime(item["last_violation_count"], '%Y-%m-%item'))
+            expiration = datetime.date(datetime.strptime(item["last_violation_count"], '%Y-%m-%d'))
             if (expiration + timedelta(days=VIOLATIONS_RESET_DAYS)).__eq__(datetime.date(datetime.now())):
                 print('reset violazioni di ' + key)
                 item["violations_count"] = 0
@@ -271,7 +271,7 @@ async def periodic_checks():
         item[sharedFunctions.weekdays.get(datetime.today().weekday())] = 0
 
         if item["active"] is True:
-            expiration = datetime.date(datetime.strptime(item["expiration"], '%Y-%m-%item'))
+            expiration = datetime.date(datetime.strptime(item["expiration"], '%Y-%m-%d'))
             channel = bot.get_channel(MAIN_CHANNEL_ID)
             if expiration.__eq__((datetime.date(datetime.now()))):
                 guild = bot.get_guild(GUILD_ID)

--- a/bot.py
+++ b/bot.py
@@ -245,6 +245,7 @@ async def periodic_checks():
         return
     for key in prev_dict:
         item = prev_dict[key]
+        sharedFunctions.clean(item)
         count = sharedFunctions.count_messages(item)
         if count >= ACTIVE_THRESHOLD and bot.get_guild(GUILD_ID).get_member(int(key)).top_role.id not in MODERATION_ROLES_ID:
             item["active"] = True
@@ -281,8 +282,8 @@ async def periodic_checks():
     sharedFunctions.update_json_file(prev_dict, 'aflers.json')
 
 def update_counter(message):
-    """Aggiorna il contatore dell'utente che ha mandato il messaggio. Se l'utente non era presente lo aggiunge
-    al json inizializzando tutti i contatori a 0
+    """aggiorna il contatore dell'utente che ha mandato il messaggio. Se l'utente non era presente lo aggiunge
+    al json inizializzando tutti i contatori a 0. Si occupa anche di aggiornare il campo "last_message_date".
     """
     if not does_it_count(message):
         return
@@ -298,8 +299,20 @@ def update_counter(message):
         key = str(message.author.id)
         if key in prev_dict:
             d = prev_dict[key]
-            #incrementa solo il campo corrispondente al giorno corrente
-            d[sharedFunctions.weekdays.get(datetime.today().weekday())] += 1
+            if d["last_message_date"] == datetime.date(datetime.now()).__str__():   
+                #messaggi dello stesso giorno, continuo a contare
+                d["counter"] += 1
+            elif d["last_message_date"] is None:
+                #può succedere in teoria se uno riceve un warn senza aver mai scritto un messaggio (tecnicamente add_warn lo prevede)
+                #oppure se resetto il file a mano per qualche motivo
+                d["counter"] = 1
+                d["last_message_date"] = datetime.date(datetime.now()).__str__()
+            else:
+                #è finito il giorno, salva i messaggi di "counter" nel giorno corrispondente e aggiorna data ultimo messaggio
+                day = sharedFunctions.weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
+                d[day] = counter   #ah ah D-day
+                d["counter"] = 1
+                d["last_message_date"] = datetime.date(datetime.now()).__str__()
         else:
             #contatore per ogni giorno per ovviare i problemi discussi nella issue #2
             afler = {
@@ -310,17 +323,18 @@ def update_counter(message):
                 "fri": 0,
                 "sat": 0,
                 "sun": 0,
+                "counter": 1,
+                "last_message_date": datetime.date(datetime.now()).__str__(),
                 "violations_count": 0,
                 "last_violation_count": None,
                 "active": False,
                 "expiration": None
             }
-            afler[sharedFunctions.weekdays.get(datetime.today().weekday())] = 1
             prev_dict[message.author.id] = afler
         sharedFunctions.update_json_file(prev_dict, 'aflers.json')
 
 def does_it_count(message):
-    """Controlla se il messaggio ricevuto rispetta le condizioni per essere conteggiato ai fini del ruolo attivo"""
+    """controlla se il messaggio ricevuto rispetta le condizioni per essere conteggiato ai fini del ruolo attivo"""
     if message.guild is not None:
         if message.guild.id == GUILD_ID:
             if message.channel.id in ACTIVE_CHANNELS_ID:

--- a/bot.py
+++ b/bot.py
@@ -309,8 +309,9 @@ def update_counter(message):
                 d["last_message_date"] = datetime.date(datetime.now()).__str__()
             else:
                 #è finito il giorno, salva i messaggi di "counter" nel giorno corrispondente e aggiorna data ultimo messaggio
-                day = sharedFunctions.weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
-                d[day] = counter   #ah ah D-day
+                if d["counter"] != 0:
+                    day = sharedFunctions.weekdays[datetime.date(datetime.strptime(d["last_message_date"], '%Y-%m-%d')).weekday()]
+                    d[day] = d["counter"]   #ah ah D-day
                 d["counter"] = 1
                 d["last_message_date"] = datetime.date(datetime.now()).__str__()
         else:

--- a/bot.py
+++ b/bot.py
@@ -133,18 +133,18 @@ async def on_message_delete(message):
             prev_dict = json.load(file)
     except FileNotFoundError:
         return
-    d = None
+    item = None
     try:
-        d = prev_dict[str(message.author.id)]
+        item = prev_dict[str(message.author.id)]
     except KeyError:
         print('utente non presente')
         return
     finally:
-        if d is None:
+        if item is None:
             return
     #il contatore non può ovviamente andare sotto 0
-    if d[sharedFunctions.weekdays.get(datetime.today().weekday())] != 0:
-        d[sharedFunctions.weekdays.get(datetime.today().weekday())] -= 1
+    if item[sharedFunctions.weekdays.get(datetime.today().weekday())] != 0:
+        item[sharedFunctions.weekdays.get(datetime.today().weekday())] -= 1
         sharedFunctions.update_json_file(prev_dict, 'aflers.json')
         print('rimosso un messaggio')
 
@@ -261,7 +261,7 @@ async def periodic_checks():
 
         #controllo sulla data dell'ultima violazione, ed eventuale reset
         if item["last_violation_count"] is not None:
-            expiration = datetime.date(datetime.strptime(item["last_violation_count"], '%Y-%m-%d'))
+            expiration = datetime.date(datetime.strptime(item["last_violation_count"], '%Y-%m-%item'))
             if (expiration + timedelta(days=VIOLATIONS_RESET_DAYS)).__eq__(datetime.date(datetime.now())):
                 print('reset violazioni di ' + key)
                 item["violations_count"] = 0
@@ -271,7 +271,7 @@ async def periodic_checks():
         item[sharedFunctions.weekdays.get(datetime.today().weekday())] = 0
 
         if item["active"] is True:
-            expiration = datetime.date(datetime.strptime(item["expiration"], '%Y-%m-%d'))
+            expiration = datetime.date(datetime.strptime(item["expiration"], '%Y-%m-%item'))
             channel = bot.get_channel(MAIN_CHANNEL_ID)
             if expiration.__eq__((datetime.date(datetime.now()))):
                 guild = bot.get_guild(GUILD_ID)
@@ -298,22 +298,22 @@ def update_counter(message):
     finally:
         key = str(message.author.id)
         if key in prev_dict:
-            d = prev_dict[key]
-            if d["last_message_date"] == datetime.date(datetime.now()).__str__():   
+            item = prev_dict[key]
+            if item["last_message_date"] == datetime.date(datetime.now()).__str__():   
                 #messaggi dello stesso giorno, continuo a contare
-                d["counter"] += 1
-            elif d["last_message_date"] is None:
+                item["counter"] += 1
+            elif item["last_message_date"] is None:
                 #può succedere in teoria se uno riceve un warn senza aver mai scritto un messaggio (tecnicamente add_warn lo prevede)
                 #oppure se resetto il file a mano per qualche motivo
-                d["counter"] = 1
-                d["last_message_date"] = datetime.date(datetime.now()).__str__()
+                item["counter"] = 1
+                item["last_message_date"] = datetime.date(datetime.now()).__str__()
             else:
                 #è finito il giorno, salva i messaggi di "counter" nel giorno corrispondente e aggiorna data ultimo messaggio
-                if d["counter"] != 0:
-                    day = sharedFunctions.weekdays[datetime.date(datetime.strptime(d["last_message_date"], '%Y-%m-%d')).weekday()]
-                    d[day] = d["counter"]   #ah ah D-day
-                d["counter"] = 1
-                d["last_message_date"] = datetime.date(datetime.now()).__str__()
+                if item["counter"] != 0:
+                    day = sharedFunctions.weekdays[datetime.date(datetime.strptime(item["last_message_date"], '%Y-%m-%d')).weekday()]
+                    item[day] = item["counter"]   #ah ah D-day
+                item["counter"] = 1
+                item["last_message_date"] = datetime.date(datetime.now()).__str__()
         else:
             #contatore per ogni giorno per ovviare i problemi discussi nella issue #2
             afler = {

--- a/cogs/ModerationCog.py
+++ b/cogs/ModerationCog.py
@@ -178,6 +178,8 @@ class ModerationCog(commands.Cog):
                     "fri": 0,
                     "sat": 0,
                     "sun": 0,
+                    "counter": 0,
+                    "last_message_date": None,
                     "violations_count": number,
                     "last_violation_count": datetime.date(datetime.now()).__str__(),
                     "active": False,

--- a/cogs/sharedFunctions.py
+++ b/cogs/sharedFunctions.py
@@ -71,11 +71,11 @@ def clean(item):
         #(None) tecnicamente previsto da add_warn se uno viene warnato senza aver mai scritto
         #(Oggi) vuol dire che il bot è stato riavviato a metà giornata non devo toccare i contatori
         return
-    elif item["last_message_date"] == datetime.date(datetime.today() - timedelta(days=1)).__str__:
+    elif item["last_message_date"] == datetime.date(datetime.today() - timedelta(days=1)).__str__():
         #messaggio di ieri, devo salvare il counter nel giorno corrispondente
         day = weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
-        d[day] = counter
-        d["counter"] = 0
+        item[day] = item["counter"]
+        item["counter"] = 0
     else:
         #devo azzerare tutti i giorni della settimana tra la data segnata (esclusa) e oggi (incluso)
         #in teoria potrei anche eliminare solo il giorno precedente contando sul fatto che venga eseguito tutti i giorni

--- a/cogs/sharedFunctions.py
+++ b/cogs/sharedFunctions.py
@@ -73,13 +73,18 @@ def clean(item):
         return
     elif item["last_message_date"] == datetime.date(datetime.today() - timedelta(days=1)).__str__():
         #messaggio di ieri, devo salvare il counter nel giorno corrispondente
-        day = weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
-        item[day] = item["counter"]
-        item["counter"] = 0
+        if item["counter"] != 0:
+            day = weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
+            item[day] = item["counter"]
+            item["counter"] = 0
     else:
         #devo azzerare tutti i giorni della settimana tra la data segnata (esclusa) e oggi (incluso)
         #in teoria potrei anche eliminare solo il giorno precedente contando sul fatto che venga eseguito tutti i giorni
         #ma preferisco azzerare tutti in caso di downtime di qualche giorno
+        if item["counter"] != 0:
+            day = weekdays[datetime.date(datetime.strptime(item["last_message_date"], '%Y-%m-%d')).weekday()]
+            item[day] = item["counter"]
+            item["counter"] = 0
         last_day = datetime.date(datetime.strptime(item["last_message_date"], '%Y-%m-%d')).weekday()
         today = datetime.today().weekday()
         while(last_day != today):


### PR DESCRIPTION
Questo codice dovrebbe risolvere il problema del reset del contatore del giorno corrente al riavvio del bot. Inoltre permette di tenere traccia della data dell'ultimo messaggio di ciascun utente.

NOTA: con questo cambiamento i vecchi file aflers.json devono essere adattati prima di essere usati seguendo il seguente template.
```
afler = {
                "mon": 0,
                "tue": 0,
                "wed": 0,
                "thu": 0,
                "fri": 0,
                "sat": 0,
                "sun": 0,
                "counter": 0,
                "last_message_date": data ultimo messaggio o None,
                "violations_count": 0,
                "last_violation_count": data ultima violazione o None,
                "active": True/False,
                "expiration": scadenza attivo o None
            }
```