### PR TITLE
Incapsulamento di Afler e Archive

### DIFF
--- a/cogs/events_cog.py
+++ b/cogs/events_cog.py
@@ -432,7 +432,7 @@ class EventCog(commands.Cog):
                 await guild.get_member(id).add_roles(guild.get_role(Config.config['active_role_id']))
                 print('member ' + item.nick + ' is active')
                 channel = self.bot.get_channel(Config.config['main_channel_id'])
-                await channel.send('membro <@!' + id + '> è diventato attivo')
+                await channel.send('membro <@!' + str(id) + '> è diventato attivo')
                 
             # controllo sulla data dell'ultima violazione, ed eventuale reset
             item.reset_violations()
@@ -444,7 +444,7 @@ class EventCog(commands.Cog):
                 channel = self.bot.get_channel(Config.config['main_channel_id'])
                 guild = self.bot.get_guild(Config.config['guild_id'])
                 await guild.get_member(id).remove_roles(guild.get_role(Config.config['active_role_id']))
-                await channel.send('membro <@!' + id + '> non più attivo :(')
+                await channel.send('membro <@!' + str(id) + '> non più attivo :(')
                 item.set_inactive()
         self.archive.save()
 
@@ -591,7 +591,7 @@ def coherency_check(archive: Archive, members: List[discord.Member]) -> None:
     # salva tutti gli id dei membri presenti
     for member in members:
         if not member.bot:
-            members_ids.append(str(member.id))
+            members_ids.append(member.id)
 
     # controlla che tutti i membri archiviati siano ancora presenti
     # in caso contrario rimuove l'entry corrispondente dall'archivio

--- a/cogs/events_cog.py
+++ b/cogs/events_cog.py
@@ -19,7 +19,7 @@ from typing import List
 import discord
 from discord.ext import commands, tasks
 from utils import shared_functions
-from utils.shared_functions import Archive, BannedWords, Config
+from utils.shared_functions import Afler, Archive, BannedWords, Config
 
 class EventCog(commands.Cog):
     """Gli eventi gestiti sono elencati qua sotto, raggruppati per categoria
@@ -50,7 +50,7 @@ class EventCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.__version__ = 'v1.1.1'
-        self.archive = Archive.archive
+        self.archive = Archive.get_instance()
 
     @commands.command(brief='aggiorna lo stato del bot')
     async def updatestatus(self, ctx):
@@ -108,7 +108,18 @@ class EventCog(commands.Cog):
         if message.channel.id == Config.config['poll_channel_id']:
             guild = self.bot.get_guild(Config.config['guild_id'])
             add_proposal(message, guild)
-        update_counter(message)
+        # controlla se il messaggio è valido
+        if not does_it_count(message):
+            return
+        # controlla se il membro è già registrato nell'archivio, in caso contrario lo aggiunge
+        if message.author.id in self.archive.keys():
+            afler = self.archive.get(message.author.id)
+        else:
+            afler = Afler.new_entry(message.author.display_name)
+            self.archive.add(message.author.id, afler)
+        # incrementa il conteggio
+        afler.increase_counter()
+        self.archive.save()
 
     @commands.Cog.listener()
     async def on_message_delete(self, message):
@@ -125,19 +136,14 @@ class EventCog(commands.Cog):
             return
         if not does_it_count(message):
             return
-        item = None
         try:
-            item = self.archive[str(message.author.id)]
+            item = self.archive.get(message.author.id)
         except KeyError:
             print('utente non presente')
             return
-        if item is None:
-            return
-        # il contatore non può ovviamente andare sotto 0
-        if item['counter'] != 0:
-            item['counter'] -= 1
-            shared_functions.update_json_file(self.archive, 'aflers.json')
-            print('rimosso un messaggio')
+        else:
+            item.decrease_counter()
+            self.archive.save()
 
     @commands.Cog.listener()
     async def on_bulk_message_delete(self, messages):
@@ -153,21 +159,18 @@ class EventCog(commands.Cog):
         if not does_it_count(messages[0]):
             return
         counter = 0
+        # TODO: possibile ottimizzazione, prima contare i messaggi per ogni utente e decrementare
+        # in un colpo solo anzichè iterare su un messaggio alla volta
         for message in messages:
-            item = None
             try:
-                item = self.archive[str(message.author.id)]
+                item = self.archive.get(message.author.id)
             except KeyError:
                 print('utente non presente')
                 continue
-            finally:
-                if item is None:
-                    continue
-            # il contatore non può ovviamente andare sotto 0
-            if item['counter'] != 0:
-                item['counter'] -= 1
+            else:
+                item.decrease_counter()
                 counter += 1
-        shared_functions.update_json_file(self.archive, 'aflers.json')
+        self.archive.save()
         print('rimossi ' + str(counter) + ' messaggi')
 
     @commands.Cog.listener()
@@ -263,12 +266,8 @@ class EventCog(commands.Cog):
         """Rimuove, se presente, l'utente da aflers.json nel momento in cui lascia il server."""
         if member.bot:
             return
-        try:
-            del self.archive[str(member.id)]
-        except KeyError:
-            print('utente non trovato')
-            return
-        shared_functions.update_json_file(self.archive, 'aflers.json')
+        self.archive.remove(member.id)
+        self.archive.save()
 
     @commands.Cog.listener()
     async def on_member_update(self, before, after):
@@ -282,27 +281,9 @@ class EventCog(commands.Cog):
         if afl_role not in before.roles:
             if afl_role in after.roles:
                 # appena diventato AFL, crea entry e salva nickname
-                if not str(after.id) in self.archive:
-                    afler = {
-                        'nick': after.display_name,
-                        'last_nick_change': datetime.date(datetime.now()).__str__(),
-                        'mon': 0,
-                        'tue': 0,
-                        'wed': 0,
-                        'thu': 0,
-                        'fri': 0,
-                        'sat': 0,
-                        'sun': 0,
-                        'counter': 0,
-                        'last_message_date': None,
-                        'violations_count': 0,
-                        'last_violation_count': None,
-                        'active': False,
-                        'expiration': None,
-                        'bio': None
-                    }
-                    self.archive[str(before.id)] = afler
-                    shared_functions.update_json_file(self.archive, 'aflers.json')
+                afler = Afler.new_entry(after.display_name)
+                self.archive.add(after.id, afler)
+                self.archive.save()
             else:
                 # non è ancora AFL, libero di cambiare nick a patto che non contenga parole vietate
                 if BannedWords.contains_banned_words(after.display_name):
@@ -312,7 +293,7 @@ class EventCog(commands.Cog):
             # era già AFL, ripristino il nickname dal file
             if before.display_name != after.display_name:
                 try:
-                    old_nick = self.archive[str(after.id)]['nick']
+                    old_nick = self.archive.get(after.id).nick
                 except KeyError:
                     old_nick = before.display_name
                 await after.edit(nick=old_nick)
@@ -325,10 +306,10 @@ class EventCog(commands.Cog):
             # non ci interessa, vuol dire che ha cambiato immagine
             return
         try:
-            data = self.archive[str(before.id)]
+            item = self.archive.get(before.id)
         except KeyError:
             return
-        old_nick = data['nick']
+        old_nick = item.nick
         member = self.bot.get_guild(Config.config['guild_id']).get_member(after.id)
         if old_nick != member.nick:
             print('reset nickname a ' + old_nick)
@@ -441,43 +422,31 @@ class EventCog(commands.Cog):
                 del proposals[key]
             shared_functions.update_json_file(proposals, 'proposals.json')
         print('controllo conteggio messaggi')
-        for key in self.archive:
-            item = self.archive[key]
-            shared_functions.clean(item)
-            count = shared_functions.count_consolidated_messages(item)
-            if count >= Config.config['active_threshold'] and self.bot.get_guild(Config.config['guild_id']).get_member(int(key)).top_role.id not in Config.config['moderation_roles_id']:
-                item['active'] = True
-                item['expiration'] = datetime.date(datetime.now() + timedelta(days=Config.config['active_duration'])).__str__()
+        for id in self.archive.keys():
+            item = self.archive.get(id)
+            item.clean()
+            count = item.count_consolidated_messages()
+            if count >= Config.config['active_threshold'] and self.bot.get_guild(Config.config['guild_id']).get_member(id).top_role.id not in Config.config['moderation_roles_id']:
+                item.set_active()
                 guild = self.bot.get_guild(Config.config['guild_id'])
-                await guild.get_member(int(key)).add_roles(guild.get_role(Config.config['active_role_id']))
-                print('member ' + item['nick'] + ' is active')
+                await guild.get_member(id).add_roles(guild.get_role(Config.config['active_role_id']))
+                print('member ' + item.nick + ' is active')
                 channel = self.bot.get_channel(Config.config['main_channel_id'])
-                await channel.send('membro <@!' + key + '> è diventato attivo')
-                # azzero tutti i contatori
-                for i in shared_functions.weekdays:
-                    item[shared_functions.weekdays.get(i)] = 0
-
+                await channel.send('membro <@!' + id + '> è diventato attivo')
+                
             # controllo sulla data dell'ultima violazione, ed eventuale reset
-            if item['last_violation_count'] is not None:
-                expiration = datetime.date(datetime.strptime(item['last_violation_count'], '%Y-%m-%d'))
-                if (expiration + timedelta(days=Config.config["violations_reset_days"])) <= (datetime.date(datetime.now())):
-                    print('reset violazioni di ' + item['nick'])
-                    item['violations_count'] = 0
-                    item['last_violation_count'] = None
+            item.reset_violations()
 
             # rimuovo i messaggi contati 7 giorni fa
-            item[shared_functions.weekdays.get(datetime.today().weekday())] = 0
+            item.forget_last_week()
 
-            if item['active'] is True:
-                expiration = datetime.date(datetime.strptime(item['expiration'], '%Y-%m-%d'))
+            if item.is_active_expired():
                 channel = self.bot.get_channel(Config.config['main_channel_id'])
-                if expiration <= ((datetime.date(datetime.now()))):
-                    guild = self.bot.get_guild(Config.config['guild_id'])
-                    await guild.get_member(int(key)).remove_roles(guild.get_role(Config.config['active_role_id']))
-                    await channel.send('membro <@!' + key + '> non più attivo :(')
-                    item['active'] = False
-                    item['expiration'] = None
-        shared_functions.update_json_file(self.archive, 'aflers.json')
+                guild = self.bot.get_guild(Config.config['guild_id'])
+                await guild.get_member(id).remove_roles(guild.get_role(Config.config['active_role_id']))
+                await channel.send('membro <@!' + id + '> non più attivo :(')
+                item.set_inactive()
+        self.archive.save()
 
 def add_proposal(message: discord.Message, guild: discord.Guild) -> None:
     """Aggiunge la proposta al file proposals.json salvando timestamp e numero di membri attivi
@@ -527,57 +496,6 @@ def remove_proposal(message: discord.Message) -> None:
         print('proposta non trovata')
     else:
         shared_functions.update_json_file(proposals, 'proposals.json')
-
-def update_counter(message: discord.Message) -> None:
-    """Aggiorna il contatore dell'utente autore del messaggio passato. In caso l'utente non sia presente
-    nel file aflers.json lo aggiunge inizializzando tutti i contatori dei giorni a 0 e counter a 1.
-    Si occupa anche di aggiornare il campo 'last_message_date'.
-
-    :param message: messaggio ricevuto
-    """
-    if not does_it_count(message):
-        return
-    key = str(message.author.id)
-    if key in Archive.archive:
-        item = Archive.archive[key]
-        if item['last_message_date'] == datetime.date(datetime.now()).__str__():
-            # messaggi dello stesso giorno, continuo a contare
-            item['counter'] += 1
-        elif item['last_message_date'] is None:
-            # primo messaggio della persona
-            item['counter'] = 1
-            item['last_message_date'] = datetime.date(datetime.now()).__str__()
-        else:
-            # è finito il giorno, salva i messaggi di 'counter' nel giorno corrispondente e aggiorna data ultimo messaggio
-            if item['counter'] != 0:
-                day = shared_functions.weekdays[datetime.date(datetime.strptime(item['last_message_date'], '%Y-%m-%d')).weekday()]
-                item[day] = item['counter']
-            item['counter'] = 1
-            item['last_message_date'] = datetime.date(datetime.now()).__str__()
-    else:
-        # succede se il file viene cancellato o il bot è offline quando entra il membro
-        print('membro non presente nel file, aggiungo ora')
-        afler = {
-            'nick': message.author.display_name,
-            'last_nick_change': datetime.date(datetime.now()).__str__(),
-            'mon': 0,
-            'tue': 0,
-            'wed': 0,
-            'thu': 0,
-            'fri': 0,
-            'sat': 0,
-            'sun': 0,
-            'counter': 1,
-            'last_message_date': datetime.date(datetime.now()).__str__(),
-            'violations_count': 0,
-            'last_violation_count': None,
-            'active': False,
-            'expiration': None,
-            'bio': None
-        }
-        Archive.archive[key] = afler
-    shared_functions.update_json_file(Archive.archive, 'aflers.json')
-
 
 def does_it_count(message: discord.Message) -> bool:
     """Controlla se il canale in cui è stato mandato il messaggio passato rientra nei canali
@@ -660,7 +578,7 @@ def emoji_or_mention(content: str) -> bool:
     else:
         return False
 
-def coherency_check(archive: dict, members: List[discord.Member]) -> None:
+def coherency_check(archive: Archive, members: List[discord.Member]) -> None:
     """Controlla la coerenza tra l'elenco membri del server e l'elenco
     degli id salvati nell'archivio aflers.json
     Questo è per evitare incongruenze in caso di downtime del bot.
@@ -679,10 +597,10 @@ def coherency_check(archive: dict, members: List[discord.Member]) -> None:
     # in caso contrario rimuove l'entry corrispondente dall'archivio
     for archived in archived_ids:
         if archived not in members_ids:
-            del archive[archived]
+            archive.remove(archived)
 
     # save changes to file
-    shared_functions.update_json_file(archive, 'aflers.json')
+    archive.save()
 
 def setup(bot):
     """Entry point per il caricamento della cog"""

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -226,7 +226,7 @@ class ModerationCog(commands.Cog, name='Moderazione'):
                 penalty = 'sottoposto a sorveglianza, il prossimo sara\' un ban.'
                 channel = await member.create_dm()
                 await channel.send('Sei stato ' + penalty + ' Motivo: ' + reason + '.')
-            elif item['violations_count'] >= 4:
+            elif item.warn_count() >= 4:
                 penalty = 'bannato dal server.'
                 channel = await member.create_dm()
                 await channel.send('Sei stato ' + penalty + ' Motivo: ' + reason + '.')

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import discord
 from discord.ext import commands
 from utils import shared_functions
-from utils.shared_functions import Archive, BannedWords, Config
+from utils.shared_functions import Afler, Archive, BannedWords, Config
 
 class ModerationCog(commands.Cog, name='Moderazione'):
     """Contiene i comandi relativi alla moderazione:
@@ -19,7 +19,7 @@ class ModerationCog(commands.Cog, name='Moderazione'):
     """
     def __init__(self, bot):
         self.bot = bot
-        self.archive = Archive.archive
+        self.archive = Archive.get_instance()
 
     def cog_check(self, ctx):
         """Check sui comandi per autorizzarne l'uso solo ai moderatori."""
@@ -73,12 +73,12 @@ class ModerationCog(commands.Cog, name='Moderazione'):
         if member.bot:
             return
         try:
-            data = self.archive[str(member.id)]
+            item = self.archive.get(member.id)
         except KeyError:
             await ctx.send('Non tovato nel file :(', delete_after=5)
             return
-        data['nick'] = name
-        shared_functions.update_json_file(self.archive, 'aflers.json')
+        item.nick = name
+        self.archive.save()
         await member.edit(nick=name)
         await ctx.send('Nickname di ' + member.mention + ' ripristinato')
 
@@ -177,15 +177,15 @@ class ModerationCog(commands.Cog, name='Moderazione'):
             }
         for user in self.archive.values():
             # ricalcolato a ogni richiesta, si potrebbe cacharlo se il numero di utenti cresce
-            warnc[user['violations_count']].append(user['nick'])
+            warnc[user.warn_count()].append(user.nick)
         # rimuovo gli utenti con 0 warn per non intasare il messaggio
         del warnc[0]
         response = ''
         for k in warnc.keys():
             response += str(k) + ' warn:\n'
             userlist = ''
-            for item in warnc[k]:
-                userlist += ' - ' + item + '\n'
+            for name in warnc[k]:
+                userlist += ' - ' + name + '\n'
             if userlist == '':
                 userlist = 'Nessuno\n'
             response += userlist
@@ -216,59 +216,32 @@ class ModerationCog(commands.Cog, name='Moderazione'):
         dell'avvenuta violazione con la ragione che è stata specificata.
         """
         penalty = 'warnato.'
-        key = str(member.id)
-        if key in self.archive:
-            data = self.archive[key]
-            data['violations_count'] += number
-            data['last_violation_count'] = datetime.date(datetime.now()).__str__()
-            shared_functions.update_json_file(self.archive, 'aflers.json')
-            if data['violations_count'] <= 0:
-                data['violations_count'] = 0
-                data['last_violation_count'] = None
-                shared_functions.update_json_file(self.archive, 'aflers.json')
+        if self.archive.is_present(member.id):
+            item = self.archive.get(member.id)
+            item.modify_warn(number)
+            if number < 0:  # non deve controllare il ban se è un unwarn
                 return
-            if number < 0:  # non deve controllare se è un unwarn
-                return
-            if data['violations_count'] == 3:
+            if item.warn_count() == 3:
                 await member.add_roles(self.bot.get_guild(Config.config['guild_id']).get_role(Config.config['under_surveillance_id']))
                 penalty = 'sottoposto a sorveglianza, il prossimo sara\' un ban.'
                 channel = await member.create_dm()
-                shared_functions.update_json_file(self.archive, 'aflers.json')
                 await channel.send('Sei stato ' + penalty + ' Motivo: ' + reason + '.')
-            elif data['violations_count'] >= 4:
+            elif item['violations_count'] >= 4:
                 penalty = 'bannato dal server.'
                 channel = await member.create_dm()
                 await channel.send('Sei stato ' + penalty + ' Motivo: ' + reason + '.')
-                shared_functions.update_json_file(self.archive, 'aflers.json')
                 await member.ban(delete_message_days = 0, reason = reason)
             else:
                 channel = await member.create_dm()
-                shared_functions.update_json_file(self.archive, 'aflers.json')
                 await channel.send('Sei stato ' + penalty + ' Motivo: ' + reason + '.')
         else:
-            # contatore per ogni giorno per ovviare i problemi discussi nella issue # 2
+            # membro che non ha mai scritto nei canali conteggiati
             if number < 0:
                 return
-            afler = {
-                'nick': member.display_name,
-                'last_nick_change': datetime.date(datetime.now()).__str__(),
-                'mon': 0,
-                'tue': 0,
-                'wed': 0,
-                'thu': 0,
-                'fri': 0,
-                'sat': 0,
-                'sun': 0,
-                'counter': 0,
-                'last_message_date': None,
-                'violations_count': number,
-                'last_violation_count': datetime.date(datetime.now()).__str__(),
-                'active': False,
-                'expiration': None,
-                'bio': None
-            }
-            self.archive[key] = afler
-            shared_functions.update_json_file(self.archive, 'aflers.json')
+            afler = Afler.new_entry(member.display_name)
+            afler.modify_warn(number)
+            self.archive.add(member.id, afler)
+        self.archive.save()
 
 def setup(bot):
     """Entry point per il caricamento della cog"""

--- a/utils/shared_functions.py
+++ b/utils/shared_functions.py
@@ -277,7 +277,7 @@ class Afler():
         if count > 0:
             # modifica la data solo se sono aggiunti
             self.data['last_violation_count'] = datetime.date(datetime.now()).__str__()
-        if self.data['violations_count'] < 0:
+        if self.data['violations_count'] <= 0:
             self.data['violations_count'] = 0
             self.data['last_violation_count'] = None
 
@@ -287,7 +287,7 @@ class Afler():
         :returns: il numero di warn accumulati
         :rtype: int
         """
-        pass
+        return self.data['violations_count']
 
     ## METODI A SUPPORTO DELLA LOGICA DI CONTROLLO ATTIVO E VIOLAZIONI
 
@@ -492,6 +492,7 @@ class Archive():
         :returns: lista con tutti gli afler
         :rtype: List[Afler]
         """
+        return self.wrapped_archive.values()
     
     def save(self):
         """Salva su disco le modifiche effettuate all'archivio.

--- a/utils/shared_functions.py
+++ b/utils/shared_functions.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
 """Funzionalità condivise tra le diverse cog per facilitare la manutenzione. In particolare:
 Classi:
-- Afler
-- Archive
+- Afler per eseguire operazioni sugli elementi dell' archivio
+- Archive archivio con i dati
 - BannedWords per gestione delle parole bannate
 - Config per la gestione dei parametri di configuarazione del bot
 
@@ -15,8 +16,7 @@ Funzioni:
 import json
 import re
 from datetime import datetime, timedelta
-from typing import List
-from __future__ import annotations
+from typing import List, Optional
 
 # utile per passare dal giorno della settimana restituito da weekday() direttamente
 # al campo corrispondente nel dizionario del json
@@ -34,18 +34,40 @@ weekdays = {
 class Afler():
     """Rappresentazione di un membro del server.
     Semplifica le operazioni di lettura/scrittura quando si accede all'archivio.
+    È importante implementare questa classe tenendo separata la logica di gestione del bot
+    dalla logica di gestione dei dati degli afler.
+    Esempio: non controllare la soglia dei messaggi qua ma passare il totale all'esterno dove viene
+    fatto il controllo in base alla config del bot
 
     Attributes
     -------------
     data: Dict[] contiene i dati dell'afler
+    nick: str    contiene il nickname dell'afler
+    bio: str     contiene la bio dell'afler
+    active: bool flag per dire se è attivo o meno
 
-    Methods
+    Classmethods
     -------------
     new_entry(nick) crea un nuovo afler
     from_archive(data) crea un afler con i dati letti dall'archivio
-    nick() restituisce il nickname
+
+    Methods
+    -------------
+    last_nick_change() ritorna la data dell'ultimo cambio nickname
+    last_message_date() ritorna la data dell'ultimo messaggio valido per l'attivo
+    last_violations_count() ritorna la data di ultima violazione
+    increase_counter() incrementa il contatore messaggi
     decrease_counter() decrementa il contatore dei messaggi del giorno corrente
+    set_active() imposta l'afler come attivo
+    is_active_expired() controlla se il ruolo attivo è scaduto
+    set_inactive() rimuove l'attivo
+    modify_warn() aggiunge o rimuove warn all'afler
+    warn_count() ritorna il numero di warn
     reset_violations() azzera il numero di violazioni commesse
+    forget_last_week() azzera il contatore corrispondente a 7 giorni fa
+    clean() sistema i dati salvati al cambio di giorno
+    count_messages() conta i messaggi totali
+    count_consolidated_messages() conta solo i messaggi dei giorni precedenti a oggi
     """
     def __init__(self, data: dict) -> None:
         """
@@ -92,6 +114,7 @@ class Afler():
         """
         return cls(afler_data)
     
+    @property
     def nick(self) -> str:
         """Restituisce il nickname dell'afler.
         
@@ -99,45 +122,386 @@ class Afler():
         :rtype: str
         """
         return self.data['nick']
-
-    def decrease_counter(self) -> None:
-        """Decrementa il contatore dei messaggi del giorno corrente.
+    
+    @nick.setter
+    def nick(self, new_nick: str):
+        """Modifica il nome dell'afler.
         
-        :raises: AssertionException se il contatore è già a 0 e non deve essere decrementato
-        ulteriormente.
+        :param new_nick: nuovo nickname
         """
-        assert(self.data['counter'] != 0, 'counter è già a 0')
-        self.data['counter'] -= 1
+        self.data['nick'] = new_nick
+        self.data['last_nick_change'] = datetime.date(datetime.now()).__str__()
+
+    @property
+    def bio(self) -> None:
+        """Restituisce la bio dell'afler
+        
+        :returns: bio dell'afler
+        :rtype: str
+        """
+        return self.data['bio']
+
+    @bio.setter
+    def bio(self, bio: str) -> None:
+        """Imposta la bio dell'afler.
+        
+        :param bio: la stringa con la bio
+        """
+        self.data['bio'] = bio
+
+    @property
+    def active(self) -> bool:
+        """Ritorna lo stato attivo dell'afler.
+        
+        :returns: True se attivo, False altrimenti
+        :rtype: bool
+        """
+        return self.data['active']
+
+    def active_expiration(self) -> Optional[datetime.date]:
+        """Ritorna la data di scadenza del ruolo attivo.
+        
+        :returns: data di scadenza attivo
+        :rtype: Optional[datetime.date]
+        """
+        if self.data['expiration'] is not None:
+            return datetime.date(datetime.strptime(self.data['expiration'], '%Y-%m-%d'))
+        else:
+            return None
+
+    def last_nick_change(self) -> datetime.date:
+        """Ritorna la data dell'utlimo cambio di nickname
+        
+        :returns: data ultimo cambio
+        :rtype: datetime.date
+        """
+        return datetime.date(datetime.strptime(self.data['last_nick_change'], '%Y-%m-%d'))
+
+    def last_message_date(self) -> Optional[datetime.time]:
+        """Ritorna la data dell'ultimo messaggio valido per il conteggio dell'attivo.
+        
+        :returns: data ultimo messaggio
+        :rtype: Optional[datetime.date]
+        """
+        if self.data['last_message_date'] is not None:
+            return datetime.date(datetime.strptime(self.data['last_message_date'], '%Y-%m-%d'))
+        else:
+            return None
+
+    def last_violations_count(self) -> Optional[datetime.date]:
+        """Ritorna la data dell'ultima violazione.
+        
+        :returns: data ultima violazione
+        :rtype: Optional[datetime.date]
+        """
+        if self.data['last_violation_count'] is not None:
+            return datetime.date(datetime.strptime(self.data['last_violation_count'], '%Y-%m-%d'))
+        else:
+            return None
+
+    def increase_counter(self) -> None:
+        """Aggiorna il contatore dell'utente autore del messaggio passato. In caso l'utente non sia presente
+        nel file aflers.json lo aggiunge inizializzando tutti i contatori dei giorni a 0 e counter a 1.
+        Si occupa anche di aggiornare il campo 'last_message_date'.
+        """
+        if self.data['last_message_date'] == datetime.date(datetime.now()).__str__():
+            # messaggi dello stesso giorno, continuo a contare
+            self.data['counter'] += 1
+        elif self.data['last_message_date'] is None:
+            # primo messaggio della persona
+            self.data['counter'] = 1
+            self.data['last_message_date'] = datetime.date(datetime.now()).__str__()
+        else:
+            # è finito il giorno, salva i messaggi di 'counter' nel giorno corrispondente e aggiorna data ultimo messaggio
+            if self.data['counter'] != 0:
+                day = weekdays[datetime.date(datetime.strptime(self.data['last_message_date'], '%Y-%m-%d')).weekday()]
+                self.data[day] = self.data['counter']
+            self.data['counter'] = 1
+            self.data['last_message_date'] = datetime.date(datetime.now()).__str__()
+
+    def decrease_counter(self, amount: int=1) -> None:
+        """Decrementa il contatore dei messaggi del giorno corrente.
+        Impedisce che il contatore vada sotto zero, in caso il parametro passato
+        sia maggiore del valore del contatore questo viene resettato a 0.
+        
+        :param amount: numero di messaggi da rimuovere
+        """
+        if self.data['counter'] - amount >= 0:
+            self.data['counter'] -= amount
+        else:
+            self.data['counter'] = 0
+
+    def set_active(self) -> None:
+        """Imposta l'afler come attivo. Consiste in tre operazioni:
+        - impostare active=True
+        - salvare la data di scadenza
+        - azzerare tutti i contatori dei messaggi
+        """
+        self.data['active'] = True
+        self.data['expiration'] = datetime.date(datetime.now() + timedelta(days=Config.config['active_duration'])).__str__()
+        for i in weekdays:
+            self.data[weekdays.get(i)] = 0
+
+    def is_active_expired(self) -> bool:
+        """Controlla se l'assegnazione del ruolo attivo è scaduta.
+        
+        :returns: True se activ=True e il ruolo è scaduto, False active=True e il ruolo è scaduto
+        oppure se l'afler non è attivo
+        :rtype: bool
+        """
+        if not self.data['active']:
+            return False
+        expiration = datetime.date(datetime.strptime(self.data['expiration'], '%Y-%m-%d'))
+        if expiration <= ((datetime.date(datetime.now()))):
+            return True
+        else: 
+            return False
+
+    def set_inactive(self) -> None:
+        """Imposta l'afler come non attivo. Consiste in due operazioni:
+        - impostare active=False
+        - impostare la data di scadenza a None
+        """
+        self.data['active'] = False
+        self.data['expiration'] = None
+
+    def modify_warn(self, count: int) -> None:
+        """Modifica il conteggio dei warn dell'afler. Il parametro count può essere sia
+        positivo (incrementare i warn) che negativo (decrementare i warn). La data di ultima violazione è
+        aggiustata di conseguenza. Impedisce di avere un totale warn negativo. Se tutti i warn sono
+        rimossi anche la data di ultima violazione è azzerata.
+
+        :param count: il numero di warn da aggiungere/rimuovere
+        """
+        self.data['violations_count'] += count
+        if count > 0:
+            # modifica la data solo se sono aggiunti
+            self.data['last_violation_count'] = datetime.date(datetime.now()).__str__()
+        if self.data['violations_count'] < 0:
+            self.data['violations_count'] = 0
+            self.data['last_violation_count'] = None
+
+    def warn_count(self) -> int:
+        """Ritorna il numero di warn che l'afler ha accumulato.
+        
+        :returns: il numero di warn accumulati
+        :rtype: int
+        """
+        pass
+
+    ## METODI A SUPPORTO DELLA LOGICA DI CONTROLLO ATTIVO E VIOLAZIONI
 
     def reset_violations(self) -> None:
-        """Azzera le violazioni dell'afler."""
-        self.data['violations_count'] = 0
-        self.data['last_violation_count'] = None
+        """Azzera le violazioni dell'afler se necessario."""
+        if self.data['last_violation_count'] is not None:
+            expiration = datetime.date(datetime.strptime(self.data['last_violation_count'], '%Y-%m-%d'))
+            if (expiration + timedelta(days=Config.config["violations_reset_days"])) <= (datetime.date(datetime.now())):
+                print('reset violazioni di ' + self.data['nick'])
+                self.data['violations_count'] = 0
+                self.data['last_violation_count'] = None
+
+    def forget_last_week(self) -> None:
+        """Rimuove dal conteggio i messaggi risalenti a 7 giorni fa."""
+        self.data[weekdays.get(datetime.today().weekday())] = 0
+
+    def clean(self) -> None:
+        """Si occupa di controllare il campo last_message_date e sistemare di conseguenza il
+        conteggio dei singoli giorni.
+        """
+        if (self.data['last_message_date'] is None) or (self.data['last_message_date'] == datetime.date(datetime.now()).__str__()):
+            # (None) tecnicamente previsto da add_warn se uno viene warnato senza aver mai scritto
+            # (Oggi) vuol dire che il bot è stato riavviato a metà giornata non devo toccare i contatori
+            return
+        elif self.data['last_message_date'] == datetime.date(datetime.today() - timedelta(days=1)).__str__():
+            # messaggio di ieri, devo salvare il counter nel giorno corrispondente
+            if self.data['counter'] != 0:
+                day = weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
+                self.data[day] = self.data['counter']
+                self.data['counter'] = 0
+        else:
+            # devo azzerare tutti i giorni della settimana tra la data segnata (esclusa) e oggi (incluso)
+            # in teoria potrei anche eliminare solo il giorno precedente contando sul fatto che venga
+            # eseguito tutti i giorni ma preferisco azzerare tutti in caso di downtime di qualche giorno
+            if self.data['counter'] != 0:
+                day = weekdays[datetime.date(datetime.strptime(self.data['last_message_date'], '%Y-%m-%d')).weekday()]
+                self.data[day] = self.data['counter']
+                self.data['counter'] = 0
+            last_day = datetime.date(datetime.strptime(self.data['last_message_date'], '%Y-%m-%d')).weekday()
+            today = datetime.today().weekday()
+            while last_day != today:
+                last_day += 1
+                if last_day > 6:
+                    last_day = 0
+                self.data[weekdays[last_day]] = 0
+
+    def count_messages(self) -> int:
+        """Ritorna il conteggio totale dei messaggi dei 7 giorni precedenti, ovvero il campo
+        counter + tutti gli altri giorni salvati escluso il giorno corrente.
+
+        :returns: il conteggio dei messaggi
+        :rtype: int
+        """
+        count = 0
+        for i in weekdays:
+            if i != datetime.today().weekday():
+                count += self.data[weekdays.get(i)]
+        count += self.data['counter']
+        return count
+
+    def count_consolidated_messages(self) -> int:
+        """Ritorna il conteggio dei messaggi salvati nei campi mon, tue, wed, ... non include counter
+        Lo scopo è contare i messaggi che sono stati consolidati nello storico ai fini di stabilire se
+        si è raggiunta la soglia dell'attivo.
+
+        :returns: il conteggio dei messaggi
+        :rtype: int
+        """
+        count = 0
+        for i in weekdays:
+            count += self.data[weekdays.get(i)]
+        return count
 
 # archivio con i dati
 class Archive():
     """Gestione dell'archivio con i dati riguardo i messaggi inviati.
-    L'idea è di tenerlo in memoria invece di aprire il file a ogni modifica.
+    L'idea è di tenerlo in memoria invece di aprire il file a ogni modifica. L'interfaccia è
+    simile a quella di un dizionario (leggere tutte le chiavi, tutti i valori, etc)
+    ma ci sono dei metodi specifici in più per svolgere altre funzioni.
+
+    NOTA: questa classe è pensata per essere un singleton e non va istanziata direttamente
+    ma occorre ottenere l'unica istanza tramite l'apposito metodo get_instance.
 
     Attributes
     -------------
-    archive: Dict[] attributo di classe, contiene l'archivio caricato
+    _archive: Archive   attributo di classe, contiene l'istanza dell'archivio
+
+    Classmethods
+    -------------
+    load_archive()   carica il contenuto del file nell'attributo di classe
+    get_instance()   ritorna l'unica istanza dell'archivio
 
     Methods
     -------------
-    load_archive()   carica il contenuto del file nell'attributo di classe
+    get()          ritorna i dati dell'afler richiesto
+    add()          aggiunge una nuova entry all'archivio
+    remove()       rimuove l'afler dall'archivio
+    is_present()   controlla se l'afler è presente o meno
+    keys()         ritorna gli id di tutti gli aflers salvati
+    values()       ritorna tutte le istanze di afler salvate
+    save()         salva le modifiche fatte all'archivio
     """
-    archive = {}
+    _archive_instance = None
 
-    @staticmethod
-    def load_archive():
+    def __init__(self, archive: dict) -> None:
+        # è sbagliato creare un'istanza, è un singleton
+        raise RuntimeError('Non istanziare archivio, usa Archive.get_instance()')
+
+    @classmethod
+    def get_instance(cls) -> Archive:
+        """Ritorna l'unica istanza dell'archivio."""
+        if cls._archive_instance is None:
+            cls.load_archive()
+        return cls._archive_instance
+
+    @classmethod
+    def load_archive(cls):
         """Carica l'archivio da file e lo salva in archive. Se non esiste lo crea vuoto."""
         try:
             with open('aflers.json', 'r') as file:
-                Archive.archive = json.load(file)
+                raw_archive = json.load(file)
+                # conversione degli id da str a int così come sono su discord
+                archive = {}
+                for k in raw_archive:
+                    archive[int(k)] = raw_archive[k]
         except FileNotFoundError:
             with open('aflers.json','w+') as file:
-                Archive.archive = {}
+                archive = {}
+        finally:
+            cls._archive_instance = cls.__new__(cls, archive)
+            # cls._archive_instance.archive l'archivio in formato dizionario così da poterlo salvare agevolemente
+            #
+            # cls._archive_instance.wrapped_archive ogni entry dell'archivio è incapsulata nella classe Afler
+            # per manipolarla più facilmente
+            #
+            # nota che i dati dei due attributi sono condivisi, quindi lo stato è sempre aggiornato
+            cls._archive_instance.archive = archive
+            cls._archive_instance.wrapped_archive = {}
+            for key in archive.keys():
+                cls._archive_instance.wrapped_archive[key] = Afler.from_archive(archive[key])
+    
+    def get(self, id: int) -> Afler:
+        """Recupera i dati dell'afler dato il suo id.
+        
+        :param id: id dell'afler richiesto
+        
+        :returns: i dati dell'afler richiesto
+        :rtype:  Afler
+
+        :raises: KeyError se l'afler non è presente nell'archivio
+        """
+        try:
+            return self.wrapped_archive[id]
+        except KeyError:
+            raise
+
+    def add(self, id: int, afler: Afler) -> None:
+        """Aggiunge una nuova entry all'archivio. Se era già presente
+        non fa nulla.
+        
+        :param afler: afler da aggiungere
+        """
+        if not self.is_present(id):
+            self.archive[id] = afler.data
+            self.wrapped_archive[id] = afler
+
+    def remove(self, id: int) -> None:
+        """Rimuove l'afler dall'archivio. In caso non fosse presente non fa nulla.
+        
+        :param id: id dell'afler richiesto
+        """
+        if self.is_present(id):
+            del self.wrapped_archive[id]
+            del self.archive[id]
+
+    def is_present(self, id: int) -> bool:
+        """Ritorna True se nell'archivio è presente un membro con l'id passato.
+        
+        :param id: membro richiesto
+        
+        :returns: True se il membro è presente, False altrimenti
+        :rtype: bool
+        """
+        if id in self.archive.keys() and id in self.wrapped_archive.keys():
+            return True
+        else:
+            return False
+
+    def keys(self) -> List[int]:
+        """Ritorna una lista con gli id di tutti gli aflers presenti nell'archivio.
+        Pensato per essere usato come il metodo keys() di un dizionario
+        
+        :returns: lista con tutti gli id
+        :rtype: List[int]
+        """
+        return self.archive.keys()
+
+    def values(self) -> List[Afler]:
+        """Ritorna una lista con tutti i dati degli aflers salvati nell'archivio.
+        Pensato per essere usato come il metodo values() di un dizionario
+        
+        :returns: lista con tutti gli afler
+        :rtype: List[Afler]
+        """
+    
+    def save(self):
+        """Salva su disco le modifiche effettuate all'archivio.
+        
+        NOTA: per ora non viene mai chiamato automaticamente dagli altri metodi
+        ma deve essere esplicitamente usato quando si vogliono salvare le modifiche.
+        L'idea è lasciare più flessibilità, consentendo di effettuare operazioni diverse
+        e poi salvare tutto alla fine.
+        """
+        update_json_file(self.archive, 'aflers.json')
 
 class BannedWords():
     """Gestione delle parole bannate. In particolare si occupa di caricare la lista dal rispettivo
@@ -335,69 +699,6 @@ def get_extensions() -> List[str]:
         print('nessuna estensione trovata, controlla file extensions.json')
         extensions = []
     return extensions
-
-def count_messages(item: dict) -> int:
-    """Ritorna il conteggio totale dei messaggi dei 7 giorni precedenti, ovvero il campo
-    counter + tutti gli altri giorni salvati escluso il giorno corrente.
-
-    :param item: dizionario proveniente dal file aflers.json di cui occorre contare i messaggi
-
-    :returns: il conteggio dei messaggi
-    :rtype: int
-    """
-    count = 0
-    for i in weekdays:
-        if i != datetime.today().weekday():
-            count += item[weekdays.get(i)]
-    count += item['counter']
-    return count
-
-def count_consolidated_messages(item: dict) -> int:
-    """Ritorna il conteggio dei messaggi salvati nei campi mon, tue, wed, ... non include counter
-    Lo scopo è contare i messaggi che sono stati consolidati nello storico ai fini di stabilire se
-    si è raggiunta la soglia dell'attivo.
-
-    :param item: dizionario proveniente dal file aflers.json di cui occorre contare i messaggi
-
-    :returns: il conteggio dei messaggi
-    :rtype: int
-    """
-    count = 0
-    for i in weekdays:
-        count += item[weekdays.get(i)]
-    return count
-
-def clean(item: dict) -> None:
-    """Si occupa di controllare il campo last_message_date e sistemare di conseguenza il
-    conteggio dei singoli giorni.
-
-    :param item: dizionario proveniente dal file aflers.json di cui occorre contare i messaggi
-    """
-    if (item['last_message_date'] is None) or (item['last_message_date'] == datetime.date(datetime.now()).__str__()):
-        # (None) tecnicamente previsto da add_warn se uno viene warnato senza aver mai scritto
-        # (Oggi) vuol dire che il bot è stato riavviato a metà giornata non devo toccare i contatori
-        return
-    elif item['last_message_date'] == datetime.date(datetime.today() - timedelta(days=1)).__str__():
-        # messaggio di ieri, devo salvare il counter nel giorno corrispondente
-        if item['counter'] != 0:
-            day = weekdays[datetime.date(datetime.today() - timedelta(days=1)).weekday()]
-            item[day] = item['counter']
-            item['counter'] = 0
-    else:
-        # devo azzerare tutti i giorni della settimana tra la data segnata (esclusa) e oggi (incluso)
-        # in teoria potrei anche eliminare solo il giorno precedente contando sul fatto che venga
-        # eseguito tutti i giorni ma preferisco azzerare tutti in caso di downtime di qualche giorno
-        if item['counter'] != 0:
-            day = weekdays[datetime.date(datetime.strptime(item['last_message_date'], '%Y-%m-%d')).weekday()]
-            item[day] = item['counter']
-            item['counter'] = 0
-        last_day = datetime.date(datetime.strptime(item['last_message_date'], '%Y-%m-%d')).weekday()
-        today = datetime.today().weekday()
-        while last_day != today:
-            last_day += 1
-            if last_day > 6:
-                last_day = 0
-            item[weekdays[last_day]] = 0
 
 def link_to_clean(message: str) -> str:
     """Controlla se il messaggio è un link da accorciare. In tal caso ritorna il link accorciato

--- a/utils/shared_functions.py
+++ b/utils/shared_functions.py
@@ -1,5 +1,7 @@
 """Funzionalità condivise tra le diverse cog per facilitare la manutenzione. In particolare:
 Classi:
+- Afler
+- Archive
 - BannedWords per gestione delle parole bannate
 - Config per la gestione dei parametri di configuarazione del bot
 
@@ -14,6 +16,7 @@ import json
 import re
 from datetime import datetime, timedelta
 from typing import List
+from __future__ import annotations
 
 # utile per passare dal giorno della settimana restituito da weekday() direttamente
 # al campo corrispondente nel dizionario del json
@@ -26,6 +29,90 @@ weekdays = {
     5: 'sat',
     6: 'sun'
 }
+
+# wrapper per eseguire operazioni sugli elementi dell' archivio, ossia gli aflers
+class Afler():
+    """Rappresentazione di un membro del server.
+    Semplifica le operazioni di lettura/scrittura quando si accede all'archivio.
+
+    Attributes
+    -------------
+    data: Dict[] contiene i dati dell'afler
+
+    Methods
+    -------------
+    new_entry(nick) crea un nuovo afler
+    from_archive(data) crea un afler con i dati letti dall'archivio
+    nick() restituisce il nickname
+    decrease_counter() decrementa il contatore dei messaggi del giorno corrente
+    reset_violations() azzera il numero di violazioni commesse
+    """
+    def __init__(self, data: dict) -> None:
+        """
+        :param data: dizionario che contiene i dati dell'afler
+        """
+        self.data = data
+
+    @classmethod
+    def new_entry(cls, nickname: str) -> Afler:
+        """Crea un nuovo afler.
+        
+        :param nickname: il nickname del nuovo afler
+
+        :returns: l'afler appena creato
+        :rtype: Afler
+        """
+        return cls({
+            'nick': nickname,
+            'last_nick_change': datetime.date(datetime.now()).__str__(),
+            'mon': 0,
+            'tue': 0,
+            'wed': 0,
+            'thu': 0,
+            'fri': 0,
+            'sat': 0,
+            'sun': 0,
+            'counter': 0,
+            'last_message_date': None,
+            'violations_count': 0,
+            'last_violation_count': None,
+            'active': False,
+            'expiration': None,
+            'bio': None
+        })
+
+    @classmethod
+    def from_archive(cls, afler_data: dict) -> Afler:
+        """Restituisce un afler con i valori letti dall'archivio.
+        
+        :param afler_data: i dati dell'afler letti dall'archivio
+
+        :returns: l'afler caricato
+        :rtype: Afler
+        """
+        return cls(afler_data)
+    
+    def nick(self) -> str:
+        """Restituisce il nickname dell'afler.
+        
+        :returns: il nickname dell'afler
+        :rtype: str
+        """
+        return self.data['nick']
+
+    def decrease_counter(self) -> None:
+        """Decrementa il contatore dei messaggi del giorno corrente.
+        
+        :raises: AssertionException se il contatore è già a 0 e non deve essere decrementato
+        ulteriormente.
+        """
+        assert(self.data['counter'] != 0, 'counter è già a 0')
+        self.data['counter'] -= 1
+
+    def reset_violations(self) -> None:
+        """Azzera le violazioni dell'afler."""
+        self.data['violations_count'] = 0
+        self.data['last_violation_count'] = None
 
 # archivio con i dati
 class Archive():


### PR DESCRIPTION
Migliorata la gestione dell'archivio e delle varie entry incapsulandole in due classi, Archive e Afler rispettivamente.
In questo modo eventuali modifiche alla struttura dell'archivio possono essere fatte senza dover modificare tutte i posti in cui viene utilizzato. Inoltre anche la logica di conteggio messaggi è ora in un unico posto dentro la classe Afler, la task esegue solo un controllo di soglia basandosi sulla config.

close #44, close #45